### PR TITLE
feat: Updated `protoc` to `3.20.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Protocol Buffers for Node
-A wrapper in Node for the compiled protoc from https://github.com/google/protobuf.
+A wrapper in Node for the compiled protoc from https://github.com/protocolbuffers/protobuf.
 
 ## Version
-It's currently using Protocol Buffers `v3.11.2`.
+It's currently using Protocol Buffers `v3.20.3`.
 
 ## Platforms
 Google only provides binary files for Windows, Linux and OSX in x86_64 and x86_32.

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ exports.closure = function(files, options, callback) {
  * Converts .proto files to .js files that can be used in Google Closure
  * Compiler.
  * The generated .js files require the files in
- * https://github.com/google/protobuf/tree/master/js.
+ * https://github.com/protocolbuffers/protobuf/tree/v3.20.3/js.
  * @param {?Array<string>} files the proto files.
  * @param {?function(?Error, ?Array<Vinyl>)} callback the callback method.
  */

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,15 +5,14 @@ var unzip = require("unzipper");
 var mkdirp = require("mkdirp");
 var protoc = require("../protoc.js");
 
-const protoVersion = "3.11.2";
+const protoVersion = "3.20.3";
 
 var releases = {
-  "win32_x86_32": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
-  "win32_x86_64": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
-  "linux_x86_32": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_32.zip`,
-  "linux_x86_64": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_64.zip`,
-  "darwin_x86_32": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-osx-x86_32.zip`,
-  "darwin_x86_64": `https://github.com/google/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-osx-x86_64.zip`
+  "win32_x86_32": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
+  "win32_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
+  "linux_x86_32": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_32.zip`,
+  "linux_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_64.zip`,
+  "darwin_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-osx-x86_64.zip`
 };
 
 var platform = process.platform;
@@ -44,5 +43,5 @@ if (releases[release]) {
       });
     });
 } else {
-  throw new Error("Unsupported platform. Was not able to find a proper protoc version.");
+  throw new Error(`Unsupported platform: ${release}. Was not able to find a proper protoc version.`);
 }


### PR DESCRIPTION
This PR updates the `protoc` version to `3.20.3`. The PR proposes the removal of `darwin_x86_32`, there is no such artifact, and the arm64 is not yet available for `3.20.3`.

Closes #4

Signed-off-by: dankeboy36 <dankeboy36@gmail.com>

----

Initially, I wanted to pick the most recent version of protoc (`3.21.9`), but the support of `protoc-gen-js` was removed (https://github.com/protocolbuffers/protobuf-javascript/issues/127), so I picked the latest backward compatible `protoc` version.

For example:
 - ✅ https://github.com/protocolbuffers/protobuf/tree/v3.20.3/js
 - ❌ https://github.com/protocolbuffers/protobuf/tree/v3.21.0-rc2/js

Please review. Thank you!
