### PR TITLE
Add notice to the readme for new releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,38 @@ A wrapper in Node for the compiled protoc from https://github.com/protocolbuffer
 > Note that the JavaScript generator has been removed from `protoc`, and lives in a
 > separate repository now: https://github.com/protocolbuffers/protobuf-javascript
 > Consequently, the package `protoc` no longer provides an API to generate JavaScript
-> code.
+> code, but you can easily achieve the same functionality with a small function.
+> 
+> <details><summary>Example script to call protoc from JS</summary>
+>
+> ```ts
+> import { spawnSync } from "node:child_process";
+> import { mkdtempSync, readdirSync, statSync } from "node:fs";
+> import { join } from "node:path";
+> import { tmpdir } from "node:os";
+>
+> function compile(files: string[]): string[] {
+>   const out = mkdtempSync(join(tmpdir(), "protoc-output"));
+>   // Just as an example, use --php_out to generate PHP code
+>   const ret = spawnSync(
+>     "protoc", ["--php_out=" + out, ...files],
+>     { encoding: "utf8"},
+>   );
+>   if (ret.status !== 0) {
+>     throw new Error(ret.stderr);
+>   }
+>   return readdirSync(out, { recursive: true, encoding: "utf8" }).filter((f) =>
+>     statSync(join(out, f)).isFile(),
+>   );
+> }
+>
+> // Run with `npx node example.ts`
+> console.log(compile(["proto/msg.proto"])); // [ 'Msg.php', 'GPBMetadata/Proto/Msg.php' ]
+> ```
+
+</details>
+
+
 
 The information below applies to the package `protoc` version 1.1.3 and earlier:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # Protocol Buffers for Node
 A wrapper in Node for the compiled protoc from https://github.com/protocolbuffers/protobuf.
 
+> [!IMPORTANT]
+>
+> Starting with version v21.0.x, the npm package [protoc](https://www.npmjs.com/package/protoc)
+> is maintained in the repository https://github.com/timostamm/protobuf-npm.
+>
+> For every release of `protoc` in https://github.com/protocolbuffers/protobuf, the
+> repository automatically creates a release with the same version number on npmjs.com.
+>
+> You can install the latest version with:
+>
+> ```
+> npm install --save-dev protoc@latest
+> npx protoc --version
+> ```
+>
+> Note that the JavaScript generator has been removed from `protoc`, and lives in a
+> separate repository now: https://github.com/protocolbuffers/protobuf-javascript
+> Consequently, the npm `protoc` no longer provides an API to generate JavaScript
+> code.
+
+The information below applies to the package `protoc` version 1.1.3 and earlier:
+
 ## Version
 It's currently using Protocol Buffers `v3.20.3`.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A wrapper in Node for the compiled protoc from https://github.com/protocolbuffer
 >
 > Starting with version v21.0.x, the npm package [protoc](https://www.npmjs.com/package/protoc)
 > is maintained in the repository https://github.com/timostamm/protobuf-npm.
-> For every release of `protoc` in https://github.com/protocolbuffers/protobuf, the
-> repository automatically creates a release with the same version number on npmjs.com.
 >
 > You can install the latest version with:
 >

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A wrapper in Node for the compiled protoc from https://github.com/protocolbuffer
 >
 > Starting with version v21.0.x, the npm package [protoc](https://www.npmjs.com/package/protoc)
 > is maintained in the repository https://github.com/timostamm/protobuf-npm.
->
 > For every release of `protoc` in https://github.com/protocolbuffers/protobuf, the
 > repository automatically creates a release with the same version number on npmjs.com.
 >
@@ -18,7 +17,7 @@ A wrapper in Node for the compiled protoc from https://github.com/protocolbuffer
 >
 > Note that the JavaScript generator has been removed from `protoc`, and lives in a
 > separate repository now: https://github.com/protocolbuffers/protobuf-javascript
-> Consequently, the npm `protoc` no longer provides an API to generate JavaScript
+> Consequently, the package `protoc` no longer provides an API to generate JavaScript
 > code.
 
 The information below applies to the package `protoc` version 1.1.3 and earlier:


### PR DESCRIPTION
The new releases (maintained in https://github.com/timostamm/protobuf-npm) include platform-specific binaries, and don't issue any HTTP requests during or after installation.

This fixes https://github.com/YePpHa/node-protoc/issues/13, https://github.com/YePpHa/node-protoc/issues/12, https://github.com/YePpHa/node-protoc/issues/11, and https://github.com/YePpHa/node-protoc/issues/9.

